### PR TITLE
Build, Attest (SBOM/Provenance) & Sign to Docker Hub

### DIFF
--- a/.github/workflows/build-and-push-docker-hub.yaml
+++ b/.github/workflows/build-and-push-docker-hub.yaml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       image_name:
-        description: "Name of the Docker image to build and push (e.g. user/repo)"
+        description: "Docker image name (e.g. user/repo)"
         required: true
         type: string
       image_tags:
-        description: "Comma-separated list of tags for the Docker image"
+        description: "Comma-separated list of tags"
         required: true
         type: string
       dockerfile:
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       context:
-        description: "Build context for the Docker image"
+        description: "Build context"
         required: true
         type: string
       build-args:
@@ -26,7 +26,7 @@ on:
     secrets:
       dockerhub_registry:
         required: true
-        description: "Docker Hub registry URL (e.g., docker.io)"
+        description: "Docker Hub registry (e.g. docker.io)"
       dockerhub_username:
         required: true
         description: "Docker Hub username"
@@ -35,7 +35,7 @@ on:
         description: "Docker Hub password"
 
 permissions:
-  # Needed for keyless signing with Cosign
+  # Needed for keyless signing with Cosign and checkout
   id-token: write
   contents: read
 
@@ -46,7 +46,7 @@ jobs:
       REGISTRY: ${{ secrets.dockerhub_registry }}
       IMAGE_NAME: ${{ inputs.image_name }}
     steps:
-      - name: Set Docker Image Tags
+      - name: Compute Docker image tags
         id: set-tags
         run: |
           set -euo pipefail
@@ -68,17 +68,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_password }}
 
-      # Buildx will publish:
-      # - Image (with your tags)
+      # Buildx will push:
+      # - Image (your tags)
       # - SBOM as an OCI referrer (sbom: true)
       # - SLSA provenance as an OCI referrer (provenance: true)
-      - name: Build and Push (with SBOM & provenance)
+      - name: Build & Push (with SBOM & provenance)
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -86,11 +86,11 @@ jobs:
           context: ${{ inputs.context }}
           push: true
           tags: ${{ env.tags_fixed }}
-          build-args: ${{ inputs.build-args }}
+          # Input name has a hyphen → use index notation
+          build-args: ${{ inputs['build-args'] }}
           sbom: true
-          provenance: true     # in v6 you can also use 'provenance: mode=max'
+          provenance: true # or 'provenance: mode=max' if you prefer
 
-      # Sign by digest (one signature covers all tags pointing to the same digest)
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
@@ -102,23 +102,3 @@ jobs:
           set -euo pipefail
           echo "Signing $IMAGE_REF@$DIGEST"
           cosign sign --yes "$IMAGE_REF@$DIGEST"
-
-      # Generate an SPDX SBOM locally (optional, if you want a signed attestation too)
-      - name: Generate SBOM (SPDX JSON)
-        run: |
-          set -euo pipefail
-          docker sbom ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \
-            --format spdx-json > sbom.spdx.json
-
-      # Upload the SBOM as a signed in-toto attestation
-      - name: Upload signed SBOM attestation
-        env:
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          echo "Attesting SBOM for $IMAGE_REF@$DIGEST"
-          cosign attest --yes \
-            --type spdx \
-            --predicate sbom.spdx.json \
-            "$IMAGE_REF@$DIGEST"

--- a/.github/workflows/build-and-push-docker-hub.yaml
+++ b/.github/workflows/build-and-push-docker-hub.yaml
@@ -1,10 +1,10 @@
-name: Build and Push Docker Image to Docker Hub
+name: Build, Attest (SBOM/Provenance) & Sign to Docker Hub
 
 on:
   workflow_call:
     inputs:
       image_name:
-        description: "Name of the Docker image to build and push"
+        description: "Name of the Docker image to build and push (e.g. user/repo)"
         required: true
         type: string
       image_tags:
@@ -34,25 +34,33 @@ on:
         required: true
         description: "Docker Hub password"
 
+permissions:
+  # Needed for keyless signing with Cosign
+  id-token: write
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ secrets.dockerhub_registry }}
+      IMAGE_NAME: ${{ inputs.image_name }}
     steps:
       - name: Set Docker Image Tags
         id: set-tags
         run: |
+          set -euo pipefail
           TAGS="${{ inputs.image_tags }}"
-          REGISTRY="${{ secrets.dockerhub_registry }}/${{ inputs.image_name }}"
           IFS=',' read -ra ELEMENTS <<< "$TAGS"
           TAGS_FIXED=""
           for ELEMENT in "${ELEMENTS[@]}"; do
-            TAGS_FIXED+="$REGISTRY:$ELEMENT,"
+            TAGS_FIXED+="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$ELEMENT,"
           done
           TAGS_FIXED=${TAGS_FIXED%,}
           echo "tags_fixed=$TAGS_FIXED" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -66,11 +74,51 @@ jobs:
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_password }}
 
-      - name: Build and Push
-        uses: docker/build-push-action@v5
+      # Buildx will publish:
+      # - Image (with your tags)
+      # - SBOM as an OCI referrer (sbom: true)
+      # - SLSA provenance as an OCI referrer (provenance: true)
+      - name: Build and Push (with SBOM & provenance)
+        id: build
+        uses: docker/build-push-action@v6
         with:
           file: ${{ inputs.dockerfile }}
           context: ${{ inputs.context }}
           push: true
           tags: ${{ env.tags_fixed }}
           build-args: ${{ inputs.build-args }}
+          sbom: true
+          provenance: true     # in v6 you can also use 'provenance: mode=max'
+
+      # Sign by digest (one signature covers all tags pointing to the same digest)
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Cosign sign image by digest (keyless OIDC)
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          echo "Signing $IMAGE_REF@$DIGEST"
+          cosign sign --yes "$IMAGE_REF@$DIGEST"
+
+      # Generate an SPDX SBOM locally (optional, if you want a signed attestation too)
+      - name: Generate SBOM (SPDX JSON)
+        run: |
+          set -euo pipefail
+          docker sbom ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \
+            --format spdx-json > sbom.spdx.json
+
+      # Upload the SBOM as a signed in-toto attestation
+      - name: Upload signed SBOM attestation
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          echo "Attesting SBOM for $IMAGE_REF@$DIGEST"
+          cosign attest --yes \
+            --type spdx \
+            --predicate sbom.spdx.json \
+            "$IMAGE_REF@$DIGEST"


### PR DESCRIPTION
This PR introduces a reusable GitHub Actions workflow that automates secure container image delivery to Docker Hub.

### What it does

* Builds and pushes Docker images using `docker/build-push-action` with Buildx and QEMU for multi-architecture builds.
* Generates and attaches SBOMs (Software Bill of Materials) as OCI referrers (`sbom: true`).
* Generates and attaches SLSA provenance attestations (`provenance: true`).
* Signs images by digest with [[Cosign](https://github.com/sigstore/cosign)](https://github.com/sigstore/cosign) in keyless OIDC mode, ensuring authenticity and integrity.

### Inputs

* `image_name`: Docker image name (e.g. `user/repo`)
* `image_tags`: Comma-separated list of tags to apply
* `dockerfile`: Path to the Dockerfile
* `context`: Build context
* `build-args`: Optional Docker build args

### Secrets

* `dockerhub_registry`: Docker Hub registry (e.g. `docker.io`)
* `dockerhub_username`: Docker Hub username
* `dockerhub_password`: Docker Hub password

### Benefits

* Provides a secure supply chain workflow aligned with [[SLSA](https://slsa.dev/)](https://slsa.dev) and [[Sigstore](https://sigstore.dev/)](https://sigstore.dev).
* Ensures reproducibility and transparency through published SBOMs and provenance.
* Validates integrity by signing all image digests with Cosign.
* Reusable across repositories and versioned via `workflow_call`.